### PR TITLE
Fixed Spawn Spacer Readme format

### DIFF
--- a/entities/spawnSpacer/README.md
+++ b/entities/spawnSpacer/README.md
@@ -5,8 +5,10 @@ This entity script spaces users out in the enclosed area for objects positioned 
 1. Create a cube or zone.
 2. Position this entity **exactly** where the users will be teleporting in.
 3. Size the entity in whole numbers (example: x:5.0, z:5.0, x:6.0, z:9.0).
+
    The y axis doesn't matter for now, but in the future, the hope is to have it be another setting for how far people should be spread apart (y:1.0 = 1m)
 4. Set the entity to be _Collisionless_.
+
    This does not apply to zones.
 5. Install the script in the _Script Url_.
 6. Done!

--- a/entities/spawnSpacer/README.md
+++ b/entities/spawnSpacer/README.md
@@ -4,12 +4,10 @@ This entity script spaces users out in the enclosed area for objects positioned 
 ### How to Setup
 1. Create a cube or zone.
 2. Position this entity **exactly** where the users will be teleporting in.
-3. Size the entity in whole numbers (example: x:5.0, z:5.0, x:6.0, z:9.0).
-
-   The y axis doesn't matter for now, but in the future, the hope is to have it be another setting for how far people should be spread apart (y:1.0 = 1m)
-4. Set the entity to be _Collisionless_.
-
-   This does not apply to zones.
+3. Size the entity in whole numbers (example: x:5.0, z:5.0, x:6.0, z:9.0).  
+  The y axis doesn't matter for now, but in the future, the hope is to have it be another setting for how far people should be spread apart (y:1.0 = 1m).  
+4. Set the entity to be _Collisionless_.  
+  This does **not** apply to zones.
 5. Install the script in the _Script Url_.
 6. Done!
 

--- a/entities/spawnSpacer/README.md
+++ b/entities/spawnSpacer/README.md
@@ -5,9 +5,9 @@ This entity script spaces users out in the enclosed area for objects positioned 
 1. Create a cube or zone.
 2. Position this entity **exactly** where the users will be teleporting in.
 3. Size the entity in whole numbers (example: x:5.0, z:5.0, x:6.0, z:9.0).
-...The y axis doesn't matter for now, but in the future, the hope is to have it be another setting for how far people should be spread apart (y:1.0 = 1m)
+   The y axis doesn't matter for now, but in the future, the hope is to have it be another setting for how far people should be spread apart (y:1.0 = 1m)
 4. Set the entity to be _Collisionless_.
-...This does not apply to zones.
+   This does not apply to zones.
 5. Install the script in the _Script Url_.
 6. Done!
 


### PR DESCRIPTION
The set up was done wrong due to misreading how the MD format worked. I have fixed this thanks to a previewer and am submitting the fixes here.